### PR TITLE
chore: install `cross-env` for Windows support

### DIFF
--- a/cy-tests/package.json
+++ b/cy-tests/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "cy:open": "node_modules/.bin/cypress open",
-    "cy:run": "node_modules/.bin/cypress run"
+    "cy:open": "cross-env node_modules/.bin/cypress open",
+    "cy:run": "cross-env node_modules/.bin/cypress run"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cross-env": "^7.0.3",
     "cypress": "^8.4.1"
   }
 }


### PR DESCRIPTION
### Type:
* cicd: helm, docker & cicd adjustments.
* ~feature: new capabilities.~
* ~fix: bug, hotfix, etc.~
* ~refactor: enhacements.~
* ~style: changes in styles.~
* ~other: docs, tests.~

### What's the focus of this PR:
The scripts in the `package.json` file of the `cypress` folder were not working when run on a Windows machine, where their execution resulted in command not found errors. This issue has been fixed by adding `cross-env` to the list of dependencies, as well as using it in the conflicting scripts. 